### PR TITLE
Support `Writer` for `T` that is not `Seek`

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -80,12 +80,15 @@ pub mod mux {
                 let result = data.dest.write(buf);
                 if let Ok(num_bytes) = result {
                     // Guard against a future universe where sizeof(usize) > sizeof(u64)
-                    let num_bytes: u64 = num_bytes.try_into().unwrap();
+                    let num_bytes_u64: u64 = num_bytes.try_into().unwrap();
 
-                    data.bytes_written += num_bytes;
+                    data.bytes_written += num_bytes_u64;
+
+                    // Partial writes are considered failure
+                    num_bytes == len
+                } else {
+                    false
                 }
-
-                result.is_ok()
             }
 
             let mut writer_data = Box::pin(MuxWriterData {

--- a/src/sys/ffi.cpp
+++ b/src/sys/ffi.cpp
@@ -65,6 +65,7 @@ extern "C" {
                               FfiMkvWriter::SetPositionFun set_position,
                               FfiMkvWriter::ElementStartNotifyFun element_start_notify,
                               void* user_data) {
+    // Even for non-seekable streams, the writer will query the current position
     if(write == nullptr || get_position == nullptr) {
       return nullptr;
     }


### PR DESCRIPTION
Resolves https://github.com/DiamondLovesYou/rust-webm/issues/17

As discussed there, this adds a new `Writer::new_non_seek()` function for supporting writers that are not `Seek`. `Seek` writers continue to use `Writer::new()` as before. This should be covered by a minor semver bump.

The tricky part was that even without `Seek`, libwebm still expects you to provide a `get_position` method. I had to expand the `Pin<Box<T>` to a new `Pin<Box<MuxWriterData<T>>>` that also tracks the number of bytes written, and returns that as the position for non-`Seek` writers. `Seek` writers continue to use `stream_position()` as before.

I made one other change: `write_fn` was previously returning success if any number of bytes were written, and was not checking if it was the intended number, as [libwebm does](https://github.com/webmproject/libwebm/blob/26d9f667170dc75e8d759a997bb61c64dec42dda/mkvmuxer/mkvwriter.cc#L37). If you feel this breaks minor semver, we can pull it out.

`rustfmt` also reformatted some stuff automatically while I was working on this - that's in its own commit.