### PR TITLE
`MkvWriter` no longer requires `Seek`

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -148,7 +148,7 @@ pub mod mux {
 
     impl<T> MkvWriter for Writer<T>
     where
-        T: Write + Seek,
+        T: Write,
     {
         fn mkv_writer(&self) -> ffi::mux::WriterMutPtr {
             self.mkv_writer.as_ptr()


### PR DESCRIPTION
In a rather embarrassing oversight, in https://github.com/DiamondLovesYou/rust-webm/pull/18 I forgot to remove the same `Seek` requirement from `MkvWriter` as well. So you could create a `Writer` with a non-`Seek` destination, but you couldn't create any segments with it!